### PR TITLE
Improve behaviour when no log files configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ COMMANDS
     log             View logs in $PAGER
     logfiles        Print log file paths
     reload          Shortcut for bootout => bootstrap
-    tail            Tail stdout log file
+    tail            Tail logs
 
     bootout         Unload the agent
     bootstrap       Load the agent


### PR DESCRIPTION
The `log`, `logfiles` and `tail` commands will now print a message and exit with a status of 1 when no log files are configured for the agent.

Also, `tail` will now tail both stdout and stderr logs instead of just the stdout log.